### PR TITLE
fix NameError in require(): uninitialized constant ActiveRecord::Serializers

### DIFF
--- a/lib/activerecord/serializers/message_pack_serializer.rb
+++ b/lib/activerecord/serializers/message_pack_serializer.rb
@@ -1,3 +1,4 @@
+require_relative './message_pack_serializer/version'
 require 'active_record'
 require 'msgpack'
 


### PR DESCRIPTION
Because there is no ActiveRecord::Serializers namespace
, declaring `class ActiveRecord::Serializers` causes `NameError`. Loading `version.rb` fixes this issue.

I'm not sure why the tests pass, but I _guess_ rspec might load all the library files before testing.

NOTE: this issue is caused by #1.
